### PR TITLE
Fixed Sticky Headers on table and replaced 'mailto' functionality with copy email.

### DIFF
--- a/src/components/fabric/DashboardPeopleInfo.tsx
+++ b/src/components/fabric/DashboardPeopleInfo.tsx
@@ -26,6 +26,7 @@ import { Mail, Phone, Calendar, GraduationCap, Briefcase, ShieldCheck, MapPin, C
 import { PEOPLEPORTAL_SERVER_ENDPOINT } from '@/commons/config';
 import { format, formatDistanceToNow } from 'date-fns';
 import { cn } from '@/lib/utils';
+import { toast } from "sonner";
 
 // --- Interfaces matching the Backend ---
 
@@ -193,6 +194,16 @@ export const DashboardPeopleInfo = () => {
         }))
         .filter(entry => entry.teamInfo !== undefined);
 
+    const copyToClipboard = async (text: string) => {
+        try {
+            await navigator.clipboard.writeText(text);
+            toast.info("Email copied to clipboard");
+        }
+        catch (err) {
+            toast.error("Failed to copy email");
+        }    
+    };
+
     return (
         <div className="flex flex-col md:flex-row gap-8 p-6 h-full overflow-y-auto">
             {/* Left Column: User Profile Sidebar (Slim) */}
@@ -233,9 +244,12 @@ export const DashboardPeopleInfo = () => {
                     <div className="flex flex-col gap-2 text-sm text-muted-foreground border-t pt-4">
                         <div className="flex items-center gap-2">
                             <Mail className="h-4 w-4 shrink-0" />
-                            <a href={`mailto:${user.email}`} className="hover:text-primary hover:underline truncate transition-colors" title={user.email}>
+                            {/* <a href={`mailto:${user.email}`} className="hover:text-primary hover:underline truncate transition-colors" title={user.email}>
                                 {user.email}
-                            </a>
+                            </a> */}
+                            <button onClick={() => {copyToClipboard(user.email)}} className="hover:text-primary hover:underline cursor-pointer truncate transition-colors" title={user.email}>
+                                {user.email}
+                            </button>
                         </div>
 
                         {attributes?.phoneNumber && (

--- a/src/components/fabric/DashboardPeopleInfo.tsx
+++ b/src/components/fabric/DashboardPeopleInfo.tsx
@@ -244,9 +244,6 @@ export const DashboardPeopleInfo = () => {
                     <div className="flex flex-col gap-2 text-sm text-muted-foreground border-t pt-4">
                         <div className="flex items-center gap-2">
                             <Mail className="h-4 w-4 shrink-0" />
-                            {/* <a href={`mailto:${user.email}`} className="hover:text-primary hover:underline truncate transition-colors" title={user.email}>
-                                {user.email}
-                            </a> */}
                             <button onClick={() => {copyToClipboard(user.email)}} className="hover:text-primary hover:underline cursor-pointer truncate transition-colors" title={user.email}>
                                 {user.email}
                             </button>

--- a/src/components/fabric/DashboardTeamRecuitment.tsx
+++ b/src/components/fabric/DashboardTeamRecuitment.tsx
@@ -799,7 +799,7 @@ export const DashboardTeamRecruitment = () => {
                             <div className="flex flex-col gap-4">
                                 {/* Social Links */}
                                 <div className="flex gap-2">
-                                    <Button
+                                    {/* <Button
                                         variant="outline"
                                         size="sm"
                                         className="flex-1"
@@ -807,6 +807,29 @@ export const DashboardTeamRecruitment = () => {
                                         disabled={!selectedApplicationDetails?.email}
                                     >
                                         Email
+                                        <MailIcon className="ml-1 h-3 w-3" />
+                                    </Button> */}
+
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        className="flex-1"
+                                        onClick={async () => {
+                                            const email = selectedApplicationDetails?.email;
+                                            if (email) {
+                                                try {
+                                                    await navigator.clipboard.writeText(selectedApplicationDetails.email);
+                                                    toast.info("Email copied to clipboard.");
+                                                }
+                                                catch (err) {
+                                                    toast.error("Failed to copy email");
+                                                }
+                                                
+                                            }
+                                        }}
+                                        disabled={!selectedApplicationDetails?.email}
+                                    >
+                                        Copy Email
                                         <MailIcon className="ml-1 h-3 w-3" />
                                     </Button>
 

--- a/src/components/fabric/DashboardTeamRecuitment.tsx
+++ b/src/components/fabric/DashboardTeamRecuitment.tsx
@@ -799,17 +799,6 @@ export const DashboardTeamRecruitment = () => {
                             <div className="flex flex-col gap-4">
                                 {/* Social Links */}
                                 <div className="flex gap-2">
-                                    {/* <Button
-                                        variant="outline"
-                                        size="sm"
-                                        className="flex-1"
-                                        onClick={() => selectedApplicationDetails?.email && (window.location.href = `mailto:${selectedApplicationDetails.email}`)}
-                                        disabled={!selectedApplicationDetails?.email}
-                                    >
-                                        Email
-                                        <MailIcon className="ml-1 h-3 w-3" />
-                                    </Button> */}
-
                                     <Button
                                         variant="outline"
                                         size="sm"

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -6,7 +6,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-auto"
+      className="relative w-full overflow-auto max-h-1/1"
     >
       <table
         data-slot="table"


### PR DESCRIPTION
  - PeoplePortalUI/src/components/ui/table.tsx
	  - Added max-h-1/1 tailwind class to table-container div (line 9)
	  - The sticky class in TableHeader does not work without a set height.
	  - max-h-1/1 sets this height for children, so sticky works properly.

 Changed clicking email from mailto to Copy to clipboard
  - PeoplePortalUI/src/components/fabric/DashboardPeopleInfo.tsx
	  - Added Copy to Clipboard method (line 196)
	  - Added toast import (line 29)
	  - Replaced <a> element with mailto link with button element with onclick event to copyToClipboard()
  - PeoplePortalUI/src/components/fabric/DashboardTeamRecruitment.tsx
	  - Replaced 'Email' button with 'Copy Email' button (line 812)
	  - Use toasts to alert user of success or failure of copy to clipboard.