### PR TITLE
bugfix: truncate long applicant names in kanban cards

### DIFF
--- a/src/components/fabric/DashboardTeamRecuitment.tsx
+++ b/src/components/fabric/DashboardTeamRecuitment.tsx
@@ -612,8 +612,9 @@ export const DashboardTeamRecruitment = () => {
                             {(/* column */ col) => {
                                 const column = col as StageDefinition;
                                 return (
-                                    <KanbanBoard id={column.id} className="min-w-[250px] ring-inset">
-                                        <KanbanHeader >{column.name} ({applications.filter(a => a.stage === column.id).length})</KanbanHeader>
+                                    <div className="w-[250px] shrink-0">
+                                    <KanbanBoard id={column.id} className="w-full ring-inset">
+                                        <KanbanHeader>{column.name} ({applications.filter(a => a.stage === column.id).length})</KanbanHeader>
                                         <KanbanCards id={column.id}>
                                             {(item: KanbanApplicationCard) => {
                                                 return (
@@ -649,6 +650,7 @@ export const DashboardTeamRecruitment = () => {
                                             }}
                                         </KanbanCards>
                                     </KanbanBoard>
+                                    </div>
                                 )
                             }}
                         </KanbanProvider>

--- a/src/components/ui/shadcn-io/kanban/index.tsx
+++ b/src/components/ui/shadcn-io/kanban/index.tsx
@@ -130,8 +130,7 @@ export const KanbanCard = <T extends KanbanItemProps = KanbanItemProps>({
             className
           )}
         >
-          {/* Content with higher z-index for interactivity */}
-          <div className="relative z-10" style={{ padding: '0px' }}>
+          <div className="relative z-10 w-full overflow-hidden" style={{ padding: '0px' }}>
             {children ?? <p className="m-0 font-medium text-sm">{name}</p>}
           </div>
         </Card>
@@ -146,7 +145,7 @@ export const KanbanCard = <T extends KanbanItemProps = KanbanItemProps>({
               className
             )}
           >
-            <div className="relative z-10" style={{ padding: '0px' }}>
+            <div className="relative z-10 w-full overflow-hidden" style={{ padding: '0px' }}>
               {children ?? <p className="m-0 font-medium text-sm">{name}</p>}
             </div>
           </Card>
@@ -172,7 +171,7 @@ export const KanbanCards = <T extends KanbanItemProps = KanbanItemProps>({
   const items = filteredData.map((item) => item.id);
 
   return (
-    <ScrollArea className="overflow-hidden">
+    <div className="overflow-x-hidden overflow-y-auto w-full">
       <SortableContext items={items}>
         <div
           className={cn('flex flex-grow flex-col gap-2 p-2', className)}
@@ -181,8 +180,7 @@ export const KanbanCards = <T extends KanbanItemProps = KanbanItemProps>({
           {filteredData.map(children)}
         </div>
       </SortableContext>
-      <ScrollBar orientation="vertical" />
-    </ScrollArea>
+    </div>
   );
 };
 
@@ -345,7 +343,7 @@ export const KanbanProvider = <
       >
         <div
           className={cn(
-            'grid size-full auto-cols-fr grid-flow-col gap-4',
+            'flex flex-row size-full gap-4',
             className
           )}
         >


### PR DESCRIPTION
**Summary**
Fixes an issue where applicant names longer than the kanban column width would overflow 
and stretch the entire board layout. Names now truncate with an ellipsis at 250px.

**Changes**

DashboardTeamRecuitment.tsx
- Wrapped each KanbanBoard in a fixed w-[250px] shrink-0 container to enforce a hard 
   width cap on each column

kanban/index.tsx
- Changed KanbanProvider inner container from CSS grid to flexbox — the auto-cols-fr 
  grid was distributing space equally across columns, overriding width constraints
- Replaced ScrollArea in KanbanCards with a plain div (overflow-x-hidden, overflow-y-auto) 
  — ScrollArea internally renders a display:table div that bypassed the 250px column width
- Added w-full overflow-hidden to the inner z-10 wrapper in KanbanCard so truncation 
  works correctly on card content

**Dependencies removed:** ScrollArea and ScrollBar no longer used in kanban/index.tsx

**Known issues:** None