### PR TITLE
UX: dynamic tab title and fixed-width Other Applications cards

### DIFF
--- a/src/components/fabric/DashboardTeamRecuitment.tsx
+++ b/src/components/fabric/DashboardTeamRecuitment.tsx
@@ -145,6 +145,19 @@ export const DashboardTeamRecruitment = () => {
     const [isFeedbackSubmitting, setIsFeedbackSubmitting] = React.useState(false);
 
 
+    // Update browser tab title when an application is opened/closed
+    React.useEffect(() => {
+        if (selectedApplication) {
+            document.title = `${selectedApplication.name} - ${teamInfo?.attributes?.friendlyName ?? "App Dev Club"}`
+        } else {
+            document.title = "App Dev Club People Portal"
+        }
+        
+        return () => {
+            document.title = "App Dev Club People Portal"
+        }
+    }, [selectedApplication, teamInfo])
+
     // Load saved interview link on mount
     React.useEffect(() => {
         const saved = localStorage.getItem("interviewLink")
@@ -992,8 +1005,8 @@ export const DashboardTeamRecruitment = () => {
                             <p className="text-lg text-muted-foreground leading-0">Other Applications</p>
                             <div className="flex gap-2 max-w-full overflow-x-auto">
                                 {otherApplications.map((app) => (
-                                    <div key={app.id} className={`flex gap-6 p-3 rounded-md border text-sm ${app.id === selectedApplication?.id ? 'bg-primary/10 border-primary' : 'bg-background hover:bg-muted/50'}`}>
-                                        <div className="flex flex-col leading-[1]">
+                                    <div key={app.id} className={`flex gap-6 p-3 rounded-md border text-sm w-[200px] shrink-0 ${app.id === selectedApplication?.id ? 'bg-primary/10 border-primary' : 'bg-background hover:bg-muted/50'}`}>
+                                        <div className="flex flex-col leading-[1] min-w-0 flex-1">
                                             <p className="font-medium truncate">{app.teamName || 'Unknown Team'}</p>
                                             <p className="text-[10px] text-muted-foreground mt-1">Applied {new Date(app.appliedAt).toLocaleDateString()}</p>
                                         </div>


### PR DESCRIPTION
## Why
Long team names on the recruiter dashboard pushed other application 
cards out of view, and recruiters working across multiple applicant 
tabs couldn't tell them apart at a glance.

## What changed
DashboardTeamRecuitment.tsx
- Browser tab title now reflects the open applicant — it shows 
  `<applicant name> - <team name>` (e.g. "Anaya Patel - Engineering") 
  while their details are open, and resets to "App Dev Club People 
  Portal" when closed or when navigating away.
- "Other Applications" cards are fixed at 200px width with the team 
  name truncating via ellipsis; the row scrolls horizontally when 
  there are many applications.

## How to test
1. Click any applicant card to open their details — the browser 
   tab should change to show their name and team 
   (e.g. "Kai Cempura - Engineering").
2. Close the details — the tab should go back to 
   "App Dev Club People Portal".
3. With an applicant's details still open, click away to another 
   page — the tab should still reset to the default (it shouldn't 
   stay stuck on the applicant's name).
4. Open an applicant who has applied to several teams — their 
   "Other Applications" cards should all stay the same width and 
   line up neatly, and any long team name should cut off with "..." 
   instead of stretching the card.
   
<img width="1512" height="982" alt="Screenshot 2026-06-15 at 5 32 40 PM" src="https://github.com/user-attachments/assets/789c1426-654f-4331-b24d-fe88af567c29" />

