### PR TITLE
Add profile editing UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist-ssr
 !.vscode/extensions.json
 .idea
 .DS_Store
+**/.DS_Store
 *.suo
 *.ntvs*
 *.njsproj

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -148,7 +148,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar> & 
                 <NavUser user={{
                     name: props.userInfo.name,
                     email: props.userInfo.email,
-                    avatar: props.userInfo.avatar
+                    avatar: props.userInfo.avatar,
+                    pk : props.userInfo.pk
                 }} />
             </SidebarFooter>
         </Sidebar>

--- a/src/components/fabric/DashboardPeopleInfo.tsx
+++ b/src/components/fabric/DashboardPeopleInfo.tsx
@@ -16,16 +16,26 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardTitle } from '@/components/ui/card';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Mail, Phone, Calendar, GraduationCap, Briefcase, ShieldCheck, MapPin, Clock, Tag, AlertCircle, Users } from 'lucide-react';
+import { Mail, Phone, Calendar, GraduationCap, Briefcase, ShieldCheck, MapPin, Clock, Tag, AlertCircle, Users, PencilIcon, Loader2Icon, Check, ChevronsUpDown, Minus, Plus, UploadCloudIcon } from 'lucide-react';
 import { PEOPLEPORTAL_SERVER_ENDPOINT } from '@/commons/config';
 import { format, formatDistanceToNow } from 'date-fns';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { PhoneInput } from '@/components/ui/phone-input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
+import { Slider } from '@/components/ui/slider';
+import Cropper, { type Area, type Point } from 'react-easy-crop';
+import imageCompression from 'browser-image-compression';
+import { toast } from 'sonner';
 
 // --- Interfaces matching the Backend ---
 
@@ -100,6 +110,13 @@ interface TeamInformationBrief {
     peoplePortalCreation: boolean;
 }
 
+interface UMDMajor {
+    college: string;
+    major_id: string;
+    name: string;
+    url: string;
+}
+
 // Reusable Info Card Component
 const InfoItem = ({ icon: Icon, label, value, href, className }: { icon: React.ElementType, label: string, value: string | React.ReactNode, href?: string, className?: string }) => (
     <div className={cn("flex flex-col gap-1 p-3 rounded-lg border bg-card text-card-foreground shadow-sm", className)}>
@@ -119,12 +136,89 @@ const InfoItem = ({ icon: Icon, label, value, href, className }: { icon: React.E
     </div>
 );
 
+const SEASONS = ['Spring', 'Summer', 'Fall', 'Winter'];
+const YEARS = Array.from({ length: 10 }, (_, i) => new Date().getFullYear() + i);
+
+const MonthYearPicker = ({ value, onChange }: { value: string, onChange: (v: string) => void }) => {
+    const [selSeason, setSelSeason] = React.useState(() => {
+        if (value) { const idx = SEASONS.indexOf(value.split('-')[0]); return idx >= 0 ? idx : 0; }
+        return 0;
+    });
+    const [selYear, setSelYear] = React.useState(() => {
+        if (value) return parseInt(value.split('-')[1]) || new Date().getFullYear();
+        return new Date().getFullYear();
+    });
+
+    const seasonRefs = useRef<(HTMLDivElement | null)[]>([]);
+    const yearRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+    React.useEffect(() => {
+        seasonRefs.current[selSeason]?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }, [selSeason]);
+
+    React.useEffect(() => {
+        const idx = YEARS.indexOf(selYear);
+        if (idx >= 0) yearRefs.current[idx]?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }, [selYear]);
+
+    React.useEffect(() => {
+        onChange(`${SEASONS[selSeason]}-${selYear}`);
+    }, [selSeason, selYear]);
+
+    const colClass = "h-48 overflow-y-auto scrollbar-none flex flex-col items-center w-1/2 snap-y snap-mandatory";
+    const itemClass = (active: boolean) => cn(
+        "w-full text-center py-2 text-sm cursor-pointer snap-center rounded-md transition-all select-none",
+        active ? "font-bold text-foreground bg-muted" : "text-muted-foreground hover:text-foreground"
+    );
+
+    return (
+        <div className="flex gap-2 border rounded-md p-2">
+            <div className={colClass}>
+                {SEASONS.map((s, i) => (
+                    <div key={s} ref={el => { seasonRefs.current[i] = el; }} className={itemClass(i === selSeason)} onClick={() => setSelSeason(i)}>
+                        {s}
+                    </div>
+                ))}
+            </div>
+            <div className="w-px bg-border" />
+            <div className={colClass}>
+                {YEARS.map((y, i) => (
+                    <div key={y} ref={el => { yearRefs.current[i] = el; }} className={itemClass(y === selYear)} onClick={() => setSelYear(y)}>
+                        {y}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
 export const DashboardPeopleInfo = () => {
     const { userPk } = useParams<{ userPk: string }>();
     const navigate = useNavigate();
     const [user, setUser] = useState<UserInformationDetail | null>(null);
     const [userTeamsMap, setUserTeamsMap] = useState<Map<string, TeamInformationBrief>>(new Map());
     const [loading, setLoading] = useState(true);
+    const [loggedInPk, setLoggedInPk] = useState<number | null>(null);
+
+    // Edit modal state
+    const [editOpen, setEditOpen] = useState(false);
+    const [editPhone, setEditPhone] = useState('');
+    const [editMajor, setEditMajor] = useState<UMDMajor | undefined>(undefined);
+    const [editGrad, setEditGrad] = useState('');
+    const [editAvatarKey, setEditAvatarKey] = useState<string | undefined>(undefined);
+    const [editAvatarPreview, setEditAvatarPreview] = useState<string | null>(null);
+    const [isSaving, setIsSaving] = useState(false);
+    const [isUploading, setIsUploading] = useState(false);
+    const [majors, setMajors] = useState<UMDMajor[]>([]);
+    const [majorOpen, setMajorOpen] = useState(false);
+
+    // Crop state
+    const [cropImage, setCropImage] = useState<string | null>(null);
+    const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+    const [zoom, setZoom] = useState(1);
+    const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+    const [isCropOpen, setIsCropOpen] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         if (!userPk) return;
@@ -159,6 +253,136 @@ export const DashboardPeopleInfo = () => {
 
         fetchData();
     }, [userPk]);
+
+    // Fetch logged-in user's pk
+    useEffect(() => {
+        fetch(`${PEOPLEPORTAL_SERVER_ENDPOINT}/api/auth/userinfo`)
+            .then(r => r.json())
+            .then(d => setLoggedInPk(d.pk))
+            .catch(() => {});
+    }, []);
+
+    // Fetch UMD majors when edit modal opens
+    useEffect(() => {
+        if (!editOpen || majors.length > 0) return;
+        fetch('https://api.umd.io/v1/majors/list')
+            .then(r => r.json())
+            .then(setMajors)
+            .catch(() => toast.error('Failed to load majors'));
+    }, [editOpen]);
+
+    const openEdit = () => {
+        if (!user) return;
+        setEditPhone(user.attributes?.phoneNumber ?? '');
+        setEditGrad(user.attributes?.expectedGrad ?? '');
+        setEditAvatarPreview(user.avatar || null);
+        setEditAvatarKey(undefined);
+        if (user.attributes?.major) {
+            setEditMajor(majors.find(m => m.name === user.attributes.major));
+        }
+        setEditOpen(true);
+    };
+
+    const getCroppedImg = (imageSrc: string, pixelCrop: Area): Promise<Blob> => {
+        return new Promise((resolve, reject) => {
+            const image = new Image();
+            image.src = imageSrc;
+            image.onload = () => {
+                const canvas = document.createElement('canvas');
+                canvas.width = pixelCrop.width;
+                canvas.height = pixelCrop.height;
+                const ctx = canvas.getContext('2d');
+                if (!ctx) return reject(new Error('No 2d context'));
+                ctx.drawImage(image, pixelCrop.x, pixelCrop.y, pixelCrop.width, pixelCrop.height, 0, 0, pixelCrop.width, pixelCrop.height);
+                canvas.toBlob(blob => blob ? resolve(blob) : reject(new Error('Canvas empty')), 'image/webp', 1.0);
+            };
+            image.onerror = reject;
+        });
+    };
+
+    const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        const allowed = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+        if (!allowed.includes(file.type)) return toast.error('Invalid file type');
+        if (file.size > 20 * 1024 * 1024) return toast.error('File too large (max 20MB)');
+        setCrop({ x: 0, y: 0 });
+        setZoom(1);
+        const reader = new FileReader();
+        reader.onload = () => { setCropImage(reader.result as string); setIsCropOpen(true); };
+        reader.readAsDataURL(file);
+        if (fileInputRef.current) fileInputRef.current.value = '';
+    };
+
+    const processAndUpload = async () => {
+        if (!cropImage || !croppedAreaPixels || !userPk) return;
+        toast.info('Processing image...');
+        setIsUploading(true);
+        setIsCropOpen(false);
+        try {
+            const croppedBlob = await getCroppedImg(cropImage, croppedAreaPixels);
+            const compressed = await imageCompression(new File([croppedBlob], 'avatar.webp', { type: 'image/webp' }), {
+                maxSizeMB: 0.45, maxWidthOrHeight: 512, useWebWorker: true, fileType: 'image/webp'
+            });
+            const uploadFile = new File([compressed], 'avatar.webp', { type: 'image/webp' });
+            setEditAvatarPreview(URL.createObjectURL(uploadFile));
+
+            const res = await fetch(`${PEOPLEPORTAL_SERVER_ENDPOINT}/api/org/people/avatar/profile-upload-url?fileName=${encodeURIComponent(uploadFile.name)}&contentType=${encodeURIComponent(uploadFile.type)}`, { credentials: 'include' });
+            if (!res.ok) throw new Error((await res.json()).message || 'Failed to get upload URL');
+            const { uploadUrl, key, fields } = await res.json();
+
+            const formData = new FormData();
+            Object.entries(fields).forEach(([k, v]) => formData.append(k, v as string));
+            formData.append('file', uploadFile);
+            const uploadRes = await fetch(uploadUrl, { method: 'POST', body: formData });
+            if (!uploadRes.ok) throw new Error('Upload failed');
+
+            setEditAvatarKey(key);
+            toast.success('Profile picture uploaded!');
+        } catch (e: any) {
+            toast.error('Upload failed', { description: e.message });
+        } finally {
+            setIsUploading(false);
+            setCropImage(null);
+        }
+    };
+
+    const handleSave = async () => {
+        if (!userPk) return;
+        setIsSaving(true);
+        try {
+            const body: Record<string, string> = {};
+            if (editPhone !== (user?.attributes?.phoneNumber ?? '')) body.phoneNumber = editPhone;
+            if (editGrad !== (user?.attributes?.expectedGrad ?? '')) body.expectedGrad = editGrad;
+            if (editMajor && editMajor.name !== user?.attributes?.major) body.major = editMajor.name;
+            if (editAvatarKey) body.avatarKey = editAvatarKey;
+
+            if (Object.keys(body).length === 0) { setEditOpen(false); return; }
+
+            const res = await fetch(`${PEOPLEPORTAL_SERVER_ENDPOINT}/api/org/people/${userPk}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify(body)
+            });
+
+            if (!res.ok) {
+                const err = await res.json();
+                throw new Error(err.message || 'Failed to save');
+            }
+
+            toast.success('Profile updated!');
+            setEditOpen(false);
+
+            // Refresh profile data
+            const updated = await fetch(`${PEOPLEPORTAL_SERVER_ENDPOINT}/api/org/people/${userPk}`);
+            if (updated.ok) setUser(await updated.json());
+        } catch (e: any) {
+            toast.error('Failed to save', { description: e.message });
+        } finally {
+            setIsSaving(false);
+        }
+    };
 
     if (loading) {
         return (
@@ -206,7 +430,14 @@ export const DashboardPeopleInfo = () => {
                         </Avatar>
 
                         <div className="space-y-0.5 mt-2 w-full">
-                            <h1 className="text-2xl font-bold tracking-tight text-foreground break-words leading-tight">{user.name}</h1>
+                            <div className="flex items-center gap-2">
+                                <h1 className="text-2xl font-bold tracking-tight text-foreground break-words leading-tight">{user.name}</h1>
+                                {loggedInPk !== null && Number(userPk) === loggedInPk && (
+                                    <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" onClick={openEdit}>
+                                        <PencilIcon className="h-4 w-4" />
+                                    </Button>
+                                )}
+                            </div>
                             <p className="text-base text-muted-foreground font-mono break-all">{user.username}</p>
                         </div>
 
@@ -264,7 +495,7 @@ export const DashboardPeopleInfo = () => {
                             <InfoItem icon={GraduationCap} label="Major" value={attributes.major} />
                         )}
                         {attributes?.expectedGrad && (
-                            <InfoItem icon={Calendar} label="Class of" value={format(new Date(attributes.expectedGrad), 'yyyy')} />
+                            <InfoItem icon={Calendar} label="Class of" value={attributes.expectedGrad} />
                         )}
                         {user.memberSince && (
                             <InfoItem icon={MapPin} label="Joined" value={format(new Date(user.memberSince), 'MMM yyyy')} />
@@ -346,6 +577,110 @@ export const DashboardPeopleInfo = () => {
                     )}
                 </section>
             </div>
+
+            {/* Edit Profile Dialog */}
+            <Dialog open={editOpen} onOpenChange={setEditOpen}>
+                <DialogContent className="max-w-lg">
+                    <DialogHeader>
+                        <DialogTitle>Edit Profile</DialogTitle>
+                    </DialogHeader>
+
+                    <div className="flex flex-col gap-5 py-2">
+                        {/* Avatar */}
+                        <div className="flex flex-col items-center gap-2">
+                            <Avatar
+                                className="h-24 w-24 cursor-pointer ring-2 ring-muted hover:ring-primary transition-all"
+                                onClick={() => fileInputRef.current?.click()}
+                            >
+                                <AvatarImage src={editAvatarPreview ?? undefined} className="object-cover" />
+                                <AvatarFallback>
+                                    {isUploading ? <Loader2Icon className="h-6 w-6 animate-spin" /> : <UploadCloudIcon className="h-6 w-6" />}
+                                </AvatarFallback>
+                            </Avatar>
+                            <p className="text-xs text-muted-foreground">Click to change photo</p>
+                            <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={onFileChange} />
+                        </div>
+
+                        {/* Major */}
+                        <div className="grid gap-1.5">
+                            <Label>Major</Label>
+                            <Popover modal open={majorOpen} onOpenChange={setMajorOpen}>
+                                <PopoverTrigger asChild>
+                                    <Button variant="outline" role="combobox" className="justify-between">
+                                        {editMajor ? editMajor.name : 'Select major'}
+                                        <ChevronsUpDown className="ml-2 h-4 w-4 opacity-50" />
+                                    </Button>
+                                </PopoverTrigger>
+                                <PopoverContent className="w-[400px] p-0 max-h-[32rem] overflow-hidden">
+                                    <Command>
+                                        <CommandInput placeholder="Search UMD major..." />
+                                        <CommandList className="flex-1 min-h-0 max-h-[24rem] overflow-y-auto">
+                                            <CommandEmpty>No majors found.</CommandEmpty>
+                                            <CommandGroup>
+                                                {majors.map(m => (
+                                                    <CommandItem key={m.major_id} value={m.name} onSelect={() => { setEditMajor(m); setMajorOpen(false); }}>
+                                                        <div className="flex flex-col">
+                                                            <span>{m.name}</span>
+                                                            <span className="text-xs text-muted-foreground">{m.college}</span>
+                                                        </div>
+                                                        <Check className={cn('ml-auto h-4 w-4', editMajor?.major_id === m.major_id ? 'opacity-100' : 'opacity-0')} />
+                                                    </CommandItem>
+                                                ))}
+                                            </CommandGroup>
+                                        </CommandList>
+                                    </Command>
+                                </PopoverContent>
+                            </Popover>
+                        </div>
+
+                        {/* Expected Graduation */}
+                        <div className="grid gap-1.5">
+                            <Label>Expected Graduation</Label>
+                            <MonthYearPicker value={editGrad} onChange={setEditGrad} />
+                        </div>
+
+                        {/* Phone */}
+                        <div className="grid gap-1.5">
+                            <Label>Phone Number</Label>
+                            <PhoneInput defaultCountry="US" value={editPhone} onChange={setEditPhone} placeholder="Enter phone number" />
+                        </div>
+                    </div>
+
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setEditOpen(false)}>Cancel</Button>
+                        <Button onClick={handleSave} disabled={isSaving || isUploading}>
+                            {isSaving && <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />}
+                            Save Changes
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Crop Dialog */}
+            <Dialog open={isCropOpen} onOpenChange={open => { setIsCropOpen(open); if (!open) setCropImage(null); }}>
+                <DialogContent className="max-w-xl">
+                    <DialogHeader>
+                        <DialogTitle>Crop Profile Picture</DialogTitle>
+                    </DialogHeader>
+                    <div className="relative h-[350px] w-full bg-muted rounded-md overflow-hidden mt-2">
+                        {cropImage && (
+                            <Cropper image={cropImage} crop={crop} zoom={zoom} aspect={1}
+                                onCropChange={setCrop} onZoomChange={setZoom}
+                                onCropComplete={(_, pixels) => setCroppedAreaPixels(pixels)}
+                            />
+                        )}
+                    </div>
+                    <div className="flex items-center gap-4 mt-3">
+                        <Minus className="h-4 w-4 cursor-pointer" onClick={() => setZoom(z => Math.max(1, z - 0.1))} />
+                        <Slider value={[zoom]} min={1} max={3} step={0.1} onValueChange={v => setZoom(v[0])} className="flex-1" />
+                        <Plus className="h-4 w-4 cursor-pointer" onClick={() => setZoom(z => Math.min(3, z + 0.1))} />
+                    </div>
+                    <DialogFooter className="mt-2">
+                        <Button variant="outline" onClick={() => setIsCropOpen(false)}>Cancel</Button>
+                        <Button onClick={processAndUpload}>Crop & Upload</Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 };

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -43,6 +43,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar"
+import { useNavigate } from "react-router-dom"
 
 export function NavUser({
   user,
@@ -51,9 +52,11 @@ export function NavUser({
     name: string
     email: string
     avatar: string
+    pk: number
   }
 }) {
   const { isMobile } = useSidebar()
+  const navigate = useNavigate()
 
   const getFallbackAvatar = () => {
     const nameArray = user.name.split(" ");
@@ -104,7 +107,7 @@ export function NavUser({
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuItem>
+              <DropdownMenuItem onClick={() => navigate(`/org/people/${user.pk}`)}>
                 <BadgeCheck />
                 Account
               </DropdownMenuItem>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -19,7 +19,7 @@ function Command({
     <CommandPrimitive
       data-slot="command"
       className={cn(
-        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        "bg-popover text-popover-foreground flex h-full w-full flex-col min-h-0 overflow-hidden rounded-md",
         className
       )}
       {...props}
@@ -88,7 +88,7 @@ function CommandList({
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        "flex-1 min-h-0 max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
         className
       )}
       {...props}

--- a/src/pages/CorpDashboard.tsx
+++ b/src/pages/CorpDashboard.tsx
@@ -86,7 +86,8 @@ interface BreadcrumbItem {
 export interface CorpUserInfo {
     name: string,
     avatar: string,
-    email: string
+    email: string,
+    pk : number
 }
 
 export const CorpDashboard = () => {
@@ -96,7 +97,8 @@ export const CorpDashboard = () => {
     const [userInfo, setUserInfo] = React.useState<CorpUserInfo>({
         name: "Unknown",
         email: "unknown@unknown.local",
-        avatar: ""
+        avatar: "",
+        pk: 0
     });
 
     React.useEffect(() => {

--- a/src/pages/UserOnboarding.tsx
+++ b/src/pages/UserOnboarding.tsx
@@ -679,10 +679,10 @@ const PersonalInfoStage = (props: PersonalInfoStageProps) => {
                             <ChevronsUpDown className="opacity-50" />
                         </Button>
                     </PopoverTrigger>
-                    <PopoverContent className="w-[600px] max-w-[600px] p-0">
+                    <PopoverContent className="w-[600px] max-w-[600px] p-0 max-h-[36rem] overflow-hidden">
                         <Command>
                             <CommandInput placeholder="Search UMD Major" className="h-9" />
-                            <CommandList>
+                            <CommandList className="flex-1 min-h-0 max-h-[24rem] overflow-y-auto">
                                 <CommandEmpty>No Majors Found</CommandEmpty>
                                 <CommandGroup>
                                     {majors.map((framework) => (


### PR DESCRIPTION
## Description

Frontend for the self-service profile editor. Pairs with the backend PR:
https://github.com/candiedoperation/PeoplePortalServer/pull/55 — that must land for this to function.

- **Account → profile navigation**: `pk` threaded through `CorpDashboard` →
  `AppSidebar` → `NavUser`, so the "Account" menu item navigates to
  `/org/people/{pk}` (previously a non-functional placeholder)
- **Edit dialog** on `DashboardPeopleInfo`, opened by a pencil icon that only
  renders on your own profile. Fields: avatar, major (UMD API combobox),
  expected graduation (custom season/year picker), phone number
- **Avatar crop + upload**: `react-easy-crop` (1:1, zoom), client-side
  compression to ≤450 KB / 512×512 WebP, then direct presigned POST to S3
- **`command.tsx`**: scroll/overflow fix for the major-picker dropdown, used by
  both the edit dialog and onboarding
- `**/.DS_Store` added to `.gitignore`

### Notes

- Save is disabled while an upload or save is in flight — the face check adds
  real latency (S3 fetch + inference), so this is tied to the request, not a
  fixed timer.
- Face-check rejections surface as a toast from the server's error message.
- **Known minor issue**: the avatar preview doesn't revert if the server rejects
  the photo — the user sees an error toast while the rejected image is still
  shown in the dialog. Low impact (the dialog is usually closed after an error),
  but the two contradict each other. Happy to fix here if you'd rather not ship
  it.
- Rebased onto current master. My kanban column-width change turned out to be
  identical to what landed in #33, so it's dropped — that file is untouched here.

## Type of Change
- [x] New feature

## Testing

Ran the full flow locally against the backend branch:
- Opened the edit dialog from the Account menu, confirmed the pencil only shows
  on your own profile
- Updated major, graduation, and phone; confirmed the dirty-check only sends
  changed fields
- Uploaded and cropped a real photo → accepted and persisted
- Uploaded a non-face image → rejected, error toast shown

**What reviewers should check:** the avatar crop/compression flow, and whether
the preview-revert issue above is worth fixing before merge.

## Screenshots

https://github.com/user-attachments/assets/37747dd7-6624-4fe0-b022-420d4095adec

(Ignore watermark - used to compress original video so it could be pasted)


## Checklist
- [x] Self-reviewed my own code
- [x] No console.log / debug statements left in
- [x] Tested locally